### PR TITLE
[Fix] 공격상태변환 수정, 예외처리 수정

### DIFF
--- a/Q_03/.vsconfig
+++ b/Q_03/.vsconfig
@@ -1,0 +1,6 @@
+{
+  "version": "1.0",
+  "components": [
+    "Microsoft.VisualStudio.Workload.ManagedGame"
+  ]
+}

--- a/Q_04/.vsconfig
+++ b/Q_04/.vsconfig
@@ -1,0 +1,6 @@
+{
+  "version": "1.0",
+  "components": [
+    "Microsoft.VisualStudio.Workload.ManagedGame"
+  ]
+}

--- a/Q_04/Assets/Scripts/StateAttack.cs
+++ b/Q_04/Assets/Scripts/StateAttack.cs
@@ -32,7 +32,8 @@ public class StateAttack : PlayerState
 
     public override void Exit()
     {
-        Machine.ChangeState(StateType.Idle);
+        //Machine.ChangeState(StateType.Idle);
+        Debug.Log(Machine.CurrentType);
     }
 
     private void Attack()
@@ -46,8 +47,14 @@ public class StateAttack : PlayerState
         foreach (Collider col in cols)
         {
             damagable = col.GetComponent<IDamagable>();
-            damagable.TakeHit(Controller.AttackValue);
+            //damagable.TakeHit(Controller.AttackValue);
+            if (damagable != null)
+            {
+                damagable.TakeHit(Controller.AttackValue);
+            }
         }
+
+        Exit();
     }
 
     public IEnumerator DelayRoutine(Action action)
@@ -55,7 +62,7 @@ public class StateAttack : PlayerState
         yield return _wait;
 
         Attack();
-        Exit();
+        Machine.ChangeState(StateType.Idle);
     }
 
 }

--- a/Q_04/Assets/Scripts/StateIdle.cs
+++ b/Q_04/Assets/Scripts/StateIdle.cs
@@ -6,6 +6,7 @@ public class StateIdle : PlayerState
 {
     public StateIdle(PlayerController controller) : base(controller) { }
 
+
     public override void Init()
     {
         ThisType = StateType.Idle;

--- a/Q_04/Assets/Scripts/StateMachine.cs
+++ b/Q_04/Assets/Scripts/StateMachine.cs
@@ -37,6 +37,11 @@ public class StateMachine
 
     public void ChangeState(StateType state)
     {
+        if (CurrentType == state)
+        {
+            return;
+        }
+
         CurrentState.Exit();
         CurrentType = state;
         CurrentState.Enter();


### PR DESCRIPTION
-공격 상태 변환을 Exit에서 하는게 아니라 딜레이루틴에 구현하여 2초의 딜레이 후 상태가 변환될 수 있도록 수정

-데미지 받을 요소가 있을 때  TakeHit하도록 수정
-바꾸려는 상태가 현재 상태와 동일하면 수행하지 않도록 수정